### PR TITLE
9 - Upgrading to Polymer 2.x - part 2

### DIFF
--- a/cosmoz-moment-timeago.html
+++ b/cosmoz-moment-timeago.html
@@ -6,7 +6,7 @@
 
 <script type="text/javascript">
 	/*global Cosmoz*/
-	const locale = 'en';
+	const LOCALE = 'en';
 
 	class CosmozMomentTimeago extends Polymer.mixinBehaviors([
 		Cosmoz.MomentBehavior
@@ -43,7 +43,7 @@
 				locale: {
 					type: String,
 					readOnly: true,
-					value: () => locale
+					value: () => LOCALE
 				}
 			};
 		}

--- a/cosmoz-moment-timeago.html
+++ b/cosmoz-moment-timeago.html
@@ -5,6 +5,9 @@
 </dom-module>
 
 <script type="text/javascript">
+	/*global Cosmoz*/
+	const locale = 'en';
+
 	class CosmozMomentTimeago extends Polymer.mixinBehaviors([
 		Cosmoz.MomentBehavior
 	], Polymer.Element) {
@@ -36,6 +39,11 @@
 				_kicker: {
 					type: Number,
 					value: 0
+				},
+				locale: {
+					type: String,
+					readOnly: true,
+					value: () => locale
 				}
 			};
 		}
@@ -49,6 +57,9 @@
 			this.set('_intervalId', window.setInterval(function () {
 				this._kicker += 1;
 			}.bind(this), refreshInterval));
+		}
+		timeago(rawDate, locale) {
+			return Cosmoz.MomentBehavior.timeago(rawDate, locale);
 		}
 	}
 	customElements.define(CosmozMomentTimeago.is, CosmozMomentTimeago);

--- a/cosmoz-moment-timeago.html
+++ b/cosmoz-moment-timeago.html
@@ -5,48 +5,51 @@
 </dom-module>
 
 <script type="text/javascript">
-	(function () {
+	class CosmozMomentTimeago extends Polymer.mixinBehaviors([
+		Cosmoz.MomentBehavior
+	], Polymer.Element) {
 
-		Polymer({
+		static get is() {
+			return 'cosmoz-moment-timeago';
+		}
 
-			is: 'cosmoz-moment-timeago',
+		static get observers() {
+			return [
+				'refreshIntervalChanged(refreshInterval)'
+			];
+		}
 
-			behaviors: [
-				Cosmoz.MomentBehavior
-			],
-
-			properties: {
+		static get properties() {
+			return {
 				date: {
 					type: Date,
-					value: function () {
-						return new Date();
-					}
+					value: () => new Date()
+				},
+				_intervalId: {
+					type: Number,
+					value: null
 				},
 				refreshInterval: {
 					type: Number,
-					value: 60000,
-					observer: 'refreshIntervalChanged'
+					value: 60000
 				},
 				_kicker: {
 					type: Number,
 					value: 0
 				}
-			},
+			};
+		}
 
-			// Local properties
-			_intervalId: null,
+		disconnectedCallback() {
+			super.disconnectedCallback();
+			window.clearInterval(this._intervalId);
+		}
 
-			detached: function () {
-				window.clearInterval(this._intervalId);
-			},
-
-			refreshIntervalChanged: function () {
-				window.clearInterval(this._intervalId);
-				this._intervalId = window.setInterval(function () {
-					this._kicker += 1;
-				}.bind(this), this.refreshInterval);
-			}
-
-		});
-	})();
+		refreshIntervalChanged(refreshInterval) {
+			this.set('_intervalId', window.setInterval(function () {
+				this._kicker += 1;
+			}.bind(this), refreshInterval));
+		}
+	}
+	customElements.define(CosmozMomentTimeago.is, CosmozMomentTimeago);
 </script>

--- a/cosmoz-moment.html
+++ b/cosmoz-moment.html
@@ -30,7 +30,7 @@ limitations under the License.
 
 		window.Cosmoz = window.Cosmoz || {};
 
-		const localSharedMoment = moment(),
+		const LOCAL_SHARED_MOMENT = moment(),
 			momentElements = [];
 
 		/** @polymerBehavior */
@@ -41,7 +41,7 @@ limitations under the License.
 				},
 				moment: {
 					type: Object,
-					value: localSharedMoment
+					value: LOCAL_SHARED_MOMENT
 				}
 			},
 			attached() {

--- a/cosmoz-moment.html
+++ b/cosmoz-moment.html
@@ -31,7 +31,7 @@ limitations under the License.
 		window.Cosmoz = window.Cosmoz || {};
 
 		const LOCAL_SHARED_MOMENT = moment(),
-			momentElements = [];
+			MOMENT_ELEMENTS = [];
 
 		/** @polymerBehavior */
 		Cosmoz.MomentBehavior = {
@@ -45,12 +45,12 @@ limitations under the License.
 				}
 			},
 			attached() {
-				momentElements.push(this);
+				MOMENT_ELEMENTS.push(this);
 			},
 			detached() {
-				const i = momentElements.indexOf(this);
+				const i = MOMENT_ELEMENTS.indexOf(this);
 				if (i >= 0) {
-					momentElements.splice(i, 1);
+					MOMENT_ELEMENTS.splice(i, 1);
 				}
 			},
 			_ensureDate(date) {
@@ -103,7 +103,7 @@ limitations under the License.
 			localeChanged(newLocale) {
 				let locale = newLocale;
 				moment.locale(locale);
-				momentElements.forEach(element => element._setLocale(locale));
+				MOMENT_ELEMENTS.forEach(element => element._setLocale(locale));
 			}
 		}
 		customElements.define(CosmozMoment.is, CosmozMoment);

--- a/cosmoz-moment.html
+++ b/cosmoz-moment.html
@@ -12,7 +12,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-<link rel="import" href="../polymer/polymer.html">
+<link rel="import" href="../polymer/polymer-element.html">
 
 <!--`<cosmoz-moment>` is a Polymer component for centralized management of Moment.js with locale change distributed notification which very easy to use.
 
@@ -30,7 +30,7 @@ limitations under the License.
 
 		window.Cosmoz = window.Cosmoz || {};
 
-		var localSharedMoment = moment(),
+		const localSharedMoment = moment(),
 			locale = 'en',
 			momentElements = [];
 
@@ -40,65 +40,74 @@ limitations under the License.
 				locale: {
 					type: String,
 					readOnly: true,
-					value: function () {
-						return locale;
-					}
+					value: () => locale
 				},
 				moment: {
 					type: Object,
 					value: localSharedMoment
 				}
 			},
-			attached: function () {
+			attached() {
 				momentElements.push(this);
 			},
-			detached: function () {
-				var i = momentElements.indexOf(this);
+			detached() {
+				const i = momentElements.indexOf(this);
 				if (i >= 0) {
 					momentElements.splice(i, 1);
 				}
 			},
-			timeago: function (rawDate, locale) {
-				var date = this._ensureDate(rawDate);
-				if (!date) {
-					return '';
-				}
-				return moment(date).locale(locale).fromNow();
-			},
-			_ensureDate: function (date) {
-				if (date === undefined) {
+			_ensureDate(date) {
+				if (date == null) {
 					return;
 				}
 				if (date instanceof Date) {
 					return date;
 				}
 				try {
-					var dateDate = new Date(date);
+					const dateDate = new Date(date);
 				} catch (err) {
 					return;
 				}
 				return dateDate;
-			}
+			},
+			timeago(rawDate, locale) {
+				const date = this._ensureDate(rawDate);
+				if (!date) {
+					return '';
+				}
+				return moment(date).locale(locale).fromNow();
+			},
 		};
 
-		Polymer({
-			is: 'cosmoz-moment',
-			properties: {
-				/**
-				 * Locale abbreviation for Moment.js locale
-				 */
-				locale: {
-					type: String,
-					observer: 'localeChanged'
-				}
-			},
-			localeChanged: function (newLocale) {
-				locale = newLocale;
-				moment.locale(locale);
-				momentElements.forEach(function (element) {
-					element._setLocale(locale);
-				});
+		class CosmozMoment extends Polymer.Element {
+
+			static get is() {
+				return 'cosmoz-moment';
 			}
-		});
+
+			static get observers() {
+				return [
+					'localeChanged(locale)'
+				];
+			}
+
+			static get properties() {
+				return {
+					/**
+					* Locale abbreviation for Moment.js locale
+					*/
+					locale: {
+						type: String
+					}
+				};
+			}
+
+			localeChanged(newLocale) {
+				let locale = newLocale;
+				moment.locale(locale);
+				momentElements.forEach(element => element._setLocale(locale));
+			}
+		}
+		customElements.define(CosmozMoment.is, CosmozMoment);
 	</script>
 </dom-module>

--- a/cosmoz-moment.html
+++ b/cosmoz-moment.html
@@ -31,16 +31,13 @@ limitations under the License.
 		window.Cosmoz = window.Cosmoz || {};
 
 		const localSharedMoment = moment(),
-			locale = 'en',
 			momentElements = [];
 
 		/** @polymerBehavior */
 		Cosmoz.MomentBehavior = {
 			properties: {
 				locale: {
-					type: String,
-					readOnly: true,
-					value: () => locale
+					type: String
 				},
 				moment: {
 					type: Object,
@@ -57,14 +54,15 @@ limitations under the License.
 				}
 			},
 			_ensureDate(date) {
-				if (date == null) {
+				let dateDate;
+				if (date === undefined) {
 					return;
 				}
 				if (date instanceof Date) {
 					return date;
 				}
 				try {
-					const dateDate = new Date(date);
+					dateDate = new Date(date);
 				} catch (err) {
 					return;
 				}

--- a/test/cosmoz-moment-timeago.html
+++ b/test/cosmoz-moment-timeago.html
@@ -30,44 +30,40 @@
 
 		<script>
 			suite('cosmoz-moment-timeago properties', function () {
-				var baseFixture;
+				let baseFixture;
 
-				setup(function () {
+				setup(() => {
 					baseFixture = fixture('basic');
 				});
 
-				test('instantiating the element works', function () {
-					assert.equal(baseFixture.is, 'cosmoz-moment-timeago');
-				});
-
-				test('default locale is `en`', function () {
-					var locale = moment.locale();
+				test('default locale is `en`', () => {
+					const locale = moment.locale();
 					assert.isString(locale);
 					assert.equal(locale, 'en');
 				});
 
-				test('date property is instance of Date object', function () {
+				test('date property is instance of Date object', () => {
 					assert.isNotNull(baseFixture.date);
 					assert.instanceOf(baseFixture.date, Date);
 				});
 
-				test('timeago value from today date is not invalid', function () {
-					var timeagoSpan = baseFixture.$$('span');
+				test('timeago value from today date is not invalid', () => {
+					const timeagoSpan = baseFixture.$$('span');
 					assert.isNotNull(timeagoSpan);
 					assert.isString(timeagoSpan.textContent);
 					assert.notEqual(timeagoSpan.textContent, 'Invalid date', 'date has invalid value');
 				});
 			});
 
-			suite('set date property', function () {
-				var customDate;
+			suite('set date property', () => {
+				let customDate;
 
-				setup(function () {
+				setup(() => {
 					customDate = fixture('custom-date');
 				});
 
-				test('should show time ago from date', function () {
-					var timeagoSpan = customDate.$$('span');
+				test('should show time ago from date', () => {
+					const timeagoSpan = customDate.$$('span');
 					assert.isNotNull(timeagoSpan);
 					assert.isString(timeagoSpan.textContent);
 					assert.include(timeagoSpan.textContent, 'years ago');

--- a/test/cosmoz-moment-timeago.html
+++ b/test/cosmoz-moment-timeago.html
@@ -29,7 +29,7 @@
 		</test-fixture>
 
 		<script>
-			suite('cosmoz-moment-timeago properties', function () {
+			suite('cosmoz-moment-timeago properties', () => {
 				let baseFixture;
 
 				setup(() => {

--- a/test/cosmoz-moment.html
+++ b/test/cosmoz-moment.html
@@ -30,12 +30,6 @@
 
 		<script>
 			suite('cosmoz-moment properties', () => {
-				let baseFixture;
-
-				setup(() => {
-					baseFixture = fixture('basic');
-				});
-
 				test('default locale is `en`', () => {
 					const locale = moment.locale();
 					assert.isString(locale);

--- a/test/cosmoz-moment.html
+++ b/test/cosmoz-moment.html
@@ -29,32 +29,28 @@
 		</test-fixture>
 
 		<script>
-			suite('cosmoz-moment properties', function () {
-				var baseFixture;
+			suite('cosmoz-moment properties', () => {
+				let baseFixture;
 
-				setup(function () {
+				setup(() => {
 					baseFixture = fixture('basic');
 				});
 
-				test('instantiating the element works', function () {
-					assert.equal(baseFixture.is, 'cosmoz-moment');
-				});
-
-				test('default locale is `en`', function () {
-					var locale = moment.locale();
+				test('default locale is `en`', () => {
+					const locale = moment.locale();
 					assert.isString(locale);
 					assert.equal(locale, 'en');
 				});
 			});
 
-			suite('set custom locale property', function () {
-				var customLocale;
+			suite('set custom locale property', () => {
+				let customLocale;
 
-				setup(function () {
+				setup(() => {
 					customLocale = fixture('custom-locale');
 				});
 
-				test('change locale to French', function () {
+				test('change locale to French', () => {
 					customLocale.locale = 'fr';
 					assert.isString(customLocale.locale);
 					assert.equal(customLocale.locale, 'fr');


### PR DESCRIPTION
Upgrading to Polymer 2.x - part 2.

* Changed to ES6 classes, except behavior.
* Updating component and tests for linting and testing.
* Updating to ES6 syntax.

Component should work as before or better.

Issue is #9.